### PR TITLE
add unboosted APR column

### DIFF
--- a/pages/apy.tsx
+++ b/pages/apy.tsx
@@ -22,6 +22,8 @@ function addApy(se) {
     const apy = aprToApy(apr, days)
     // show apy as xx.xx%
     se[i].apy = (apy * 100).toFixed(2)
+    se[i].aprUnboosted = (apr / se[i].multiplier).toFixed(2)
+    console.log(se[i].multiplier.toFixed(2))
   }
 }
 
@@ -43,6 +45,14 @@ function addYield(se) {
   }
 }
 
+function addMultiplier(se) {
+  // iterate and take the previous and current supply events and calculate the difference
+  for (let i = 1; i < se.length; i++) {
+    se[i].multiplier =
+      bigNum18(se[i].totalSupply) / bigNum18(se[i].rebasingCredits)
+  }
+}
+
 function bigNum18(value: string): number {
   return parseFloat(ethers.utils.formatUnits(value, 18))
 }
@@ -53,6 +63,7 @@ export default function APY({ locale, onLocale }) {
   useEffect(() => {
     totalSupplyEvents().then((events) => {
       const eventsJson = events.map((s) => s.toJSON())
+      addMultiplier(eventsJson)
       addApy(eventsJson)
       addYield(eventsJson)
       eventsJson.reverse()
@@ -79,6 +90,7 @@ export default function APY({ locale, onLocale }) {
                   <th>APY</th>
                   <th>Yield</th>
                   <th>Multiplier</th>
+                  <th>APR on Total</th>
                   <th>XUSD Total</th>
                   <th>Rebasing Supply</th>
                   <th>Non-Rebasing Supply</th>
@@ -105,12 +117,9 @@ export default function APY({ locale, onLocale }) {
                       <td>
                         <strong>{supplyEvent.yield}</strong>
                       </td>
+                      <td>{supplyEvent.multiplier.toFixed(2)}x</td>
                       <td>
-                        {(
-                          bigNum18(supplyEvent.totalSupply) /
-                          bigNum18(supplyEvent.rebasingCredits)
-                        ).toFixed(2)}
-                        x
+                        <strong>{supplyEvent.aprUnboosted}%</strong>
                       </td>
                       <td>{bigNum18(supplyEvent.totalSupply).toFixed(2)}</td>
                       <td>

--- a/pages/apy.tsx
+++ b/pages/apy.tsx
@@ -20,10 +20,13 @@ function addApy(se) {
     const days = moment(currentDate).diff(moment(pastDate), 'hours') / 24
     const apr = ((ratio - 1) * 100 * 365.25) / days
     const apy = aprToApy(apr, days)
+
+    se[i].multiplier =
+      bigNum18(se[i].totalSupply) / bigNum18(se[i].rebasingCredits)
+
     // show apy as xx.xx%
     se[i].apy = (apy * 100).toFixed(2)
     se[i].aprUnboosted = (apr / se[i].multiplier).toFixed(2)
-    console.log(se[i].multiplier.toFixed(2))
   }
 }
 
@@ -45,14 +48,6 @@ function addYield(se) {
   }
 }
 
-function addMultiplier(se) {
-  // iterate and take the previous and current supply events and calculate the difference
-  for (let i = 1; i < se.length; i++) {
-    se[i].multiplier =
-      bigNum18(se[i].totalSupply) / bigNum18(se[i].rebasingCredits)
-  }
-}
-
 function bigNum18(value: string): number {
   return parseFloat(ethers.utils.formatUnits(value, 18))
 }
@@ -63,7 +58,6 @@ export default function APY({ locale, onLocale }) {
   useEffect(() => {
     totalSupplyEvents().then((events) => {
       const eventsJson = events.map((s) => s.toJSON())
-      addMultiplier(eventsJson)
       addApy(eventsJson)
       addYield(eventsJson)
       eventsJson.reverse()


### PR DESCRIPTION
Dapp change checklist:
  - [ ] Code reviewed by 1 reviewers.
  - [ ] CI passes

<img width="944" alt="image" src="https://user-images.githubusercontent.com/96358263/157538430-b7c057a2-ba48-49a0-b66d-83f04fb7bb7e.png">

I have been finding it difficult to get back the unboosted APR from the /apy page. Adding a column to make this easy.